### PR TITLE
Edit function to remove consecutive whitespace when saving to .bib file

### DIFF
--- a/R/update_bib_file_from_vector.R
+++ b/R/update_bib_file_from_vector.R
@@ -18,39 +18,48 @@
 #' verbose = TRUE
 #' )
 #' }
-update_bib_file_from_vector <- function(
-    path,
-    v_bibtex_entries,
-    output_type = "markdown_short",
-    verbose = FALSE) {
-  # check that the path_to_bib is a string and that it ends in .bib
-  if(!is.character(path) | !grepl(x = path, pattern = ".bib$")){
-    stop("path_to_bib must be a string ending in .bib")
+update_bib_file_from_vector <-
+  function (path,
+            v_bibtex_entries,
+            output_type = "markdown_short",
+            verbose = FALSE) {
+    if (!is.character(path) | !grepl(x = path, pattern = ".bib$")) {
+      stop("path_to_bib must be a string ending in .bib")
+    }
+    create_bib_if_missing(path = path, verbose = verbose)
+    existing_content <- readLines(path)
+    v_bibtex_entries_ALL <-
+      append_bibtex_entry_vec(
+        v_bibtex_entries = v_bibtex_entries,
+        existing_content = existing_content,
+        verbose = verbose
+      )
+
+    lines_to_write <- remove_consecutive_spaces(v_bibtex_entries_ALL)
+    writeLines(text = lines_to_write, con = path)
+    v_bib_tags <-
+      sapply(X = v_bibtex_entries,
+             FUN = extract_bibtex_tag,
+             output = output_type)
+    v_bib_tags <- unname(v_bib_tags)
+    return(v_bib_tags)
   }
-  # Create the bib file if missing
-  create_bib_if_missing(path = path,
-                        verbose = verbose)
 
-  # Read the existing content from the bib-file...
-  existing_content <- readLines(path)
 
-  # append the strings with the bibtex
-  v_bibtex_entries_ALL <- append_bibtex_entry_vec(
-    v_bibtex_entries = v_bibtex_entries,
-    existing_content = existing_content,
-    verbose = verbose
-  )
 
-  # write the lines to the file
-  writeLines(text = v_bibtex_entries_ALL,
-             con = path)
 
-  # create a vector of the bibtex tags
-  v_bib_tags <- sapply(X = v_bibtex_entries,
-                       FUN = extract_bibtex_tag,
-                       output = output_type)
-  # return a vector of the tags
-  v_bib_tags <- unname(v_bib_tags)
 
-  return(v_bib_tags)
+remove_consecutive_spaces <- function(x) {
+  # find all the spaces
+  v_spaces <- grep(pattern = "^\\s*$",
+                   x = x)
+  # identify consecutive spaces
+  consecutive_space_index <- v_spaces[c(FALSE, diff(v_spaces) == 1)]
+  # create a logical vector to identify consecutive spaces
+  are_consecutive_spaces <- rep(FALSE, length(x))
+  # mark the consecutive spaces as TRUE
+  are_consecutive_spaces[consecutive_space_index] <- TRUE
+  # only return the non-consecutive spaces
+  return(x[!are_consecutive_spaces])
+
 }

--- a/man/update_bib_file_from_vector.Rd
+++ b/man/update_bib_file_from_vector.Rd
@@ -35,6 +35,4 @@ v_bibtex_entries = v_example_refs,
 verbose = TRUE
 )
 }
-
-
 }


### PR DESCRIPTION
Rough go at this, will need thorough review & some testing.


This should remove any consecutive whitespace in bibtex files. For example:

```
@ref{
.....
}



@ref{
.....
}






```

should update to:

```
@ref{
.....
}

@ref{
.....
}
```
